### PR TITLE
[CMS PR #35419] Don't let pre-update checker look for extension version older than installed

### DIFF
--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -509,8 +509,8 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 
 		/** @var JoomlaupdateModelDefault $model */
 		$model = $this->getModel('default');
-		$upgradeCompatibilityStatus = $model->fetchCompatibility($extensionID, $joomlaTargetVersion);
-		$currentCompatibilityStatus = $model->fetchCompatibility($extensionID, $joomlaCurrentVersion);
+		$upgradeCompatibilityStatus = $model->fetchCompatibility($extensionID, $extensionVersion, $joomlaTargetVersion);
+		$currentCompatibilityStatus = $model->fetchCompatibility($extensionID, $extensionVersion, $joomlaCurrentVersion);
 
 		$upgradeWarning = 0;
 	

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1577,7 +1577,7 @@ ENDDATA;
 	 *
 	 * @since 3.10.0
 	 */
-	public function fetchCompatibility($extensionID, $joomlaTargetVersion)
+	public function fetchCompatibility($extensionID, $extensionVersion, $joomlaTargetVersion)
 	{
 		$updateSites = $this->getUpdateSitesInfo($extensionID);
 
@@ -1594,7 +1594,7 @@ ENDDATA;
 
 				foreach ($updateFileUrls as $updateFileUrl)
 				{
-					$compatibleVersion = $this->checkCompatibility($updateFileUrl, $joomlaTargetVersion);
+					$compatibleVersion = $this->checkCompatibility($updateFileUrl, $extensionVersion, $joomlaTargetVersion);
 
 					if ($compatibleVersion)
 					{
@@ -1610,7 +1610,7 @@ ENDDATA;
 			}
 			else
 			{
-				$compatibleVersion = $this->checkCompatibility($updateSite['location'], $joomlaTargetVersion);
+				$compatibleVersion = $this->checkCompatibility($updateSite['location'], $extensionVersion, $joomlaTargetVersion);
 
 				if ($compatibleVersion)
 				{
@@ -1739,14 +1739,14 @@ ENDDATA;
 	 *
 	 * @since   3.10.0
 	 */
-	private function checkCompatibility($updateFileUrl, $joomlaTargetVersion)
+	private function checkCompatibility($updateFileUrl, $extensionVersion, $joomlaTargetVersion)
 	{
 		// Get the minimum stability information from com_installer
 		$minimumStability = JComponentHelper::getParams('com_installer')->get('minimum_stability', JUpdater::STABILITY_STABLE);
 
 		$update = new JUpdate;
 		$update->set('jversion.full', $joomlaTargetVersion);
-		$update->loadFromXML($updateFileUrl, $minimumStability);
+		$update->loadFromXML($updateFileUrl, $minimumStability, $extensionVersion);
 
 		$downloadUrl = $update->get('downloadurl');
 

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1571,6 +1571,7 @@ ENDDATA;
 	 * Called by controller's fetchExtensionCompatibility, which is called via AJAX.
 	 *
 	 * @param   string  $extensionID          The ID of the checked extension
+	 * @param   string  $extensionVersion     The installed version of the checked extension
 	 * @param   string  $joomlaTargetVersion  Target version of Joomla
 	 *
 	 * @return object
@@ -1733,6 +1734,7 @@ ENDDATA;
 	 * Method to check non core extensions for compatibility.
 	 *
 	 * @param   string  $updateFileUrl        The items update XML url.
+	 * @param   string  $extensionVersion     The items installed version
 	 * @param   string  $joomlaTargetVersion  The Joomla! version to test against
 	 *
 	 * @return  mixed  An array of data items or false.

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -225,6 +225,14 @@ class Update extends \JObject
 	protected $minimum_stability = Updater::STABILITY_STABLE;
 
 	/**
+	 * The minimum version for updates to be taken into account
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $minimum_version = '';
+
+	/**
 	 * Gets the reference to the current direct parent
 	 *
 	 * @return  object
@@ -417,7 +425,15 @@ class Update extends \JObject
 						$stabilityMatch = false;
 					}
 
-					if ($phpMatch && $stabilityMatch && $dbMatch)
+					// Check minimum version
+					$minVersionMatch = true;
+
+					if (!empty($this->minimum_version) && version_compare($this->currentUpdate->version->_data, $this->minimum_version, '<'))
+					{
+						$minVersionMatch = false;
+					}
+
+					if ($phpMatch && $stabilityMatch && $dbMatch && $minVersionMatch)
 					{
 						if (!isset($this->latest)
 							|| version_compare($this->currentUpdate->version->_data, $this->latest->version->_data, '>'))
@@ -499,12 +515,13 @@ class Update extends \JObject
 	 *
 	 * @param   string  $url               The URL.
 	 * @param   int     $minimumStability  The minimum stability required for updating the extension {@see Updater}
+	 * @param   string  $minimumVersion    The minimum extension version to look for updates; use empty string if no limit
 	 *
 	 * @return  boolean  True on success
 	 *
 	 * @since   1.7.0
 	 */
-	public function loadFromXml($url, $minimumStability = Updater::STABILITY_STABLE)
+	public function loadFromXml($url, $minimumStability = Updater::STABILITY_STABLE, $minimumVersion = '')
 	{
 		$version    = new Version;
 		$httpOption = new Registry;
@@ -529,6 +546,7 @@ class Update extends \JObject
 		}
 
 		$this->minimum_stability = $minimumStability;
+		$this->minimum_version   = $minimumVersion;
 
 		$this->xmlParser = xml_parser_create('');
 		xml_set_object($this->xmlParser, $this);


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/35419#issuecomment-910115310 .

### Summary of Changes

Since we cannot downgrade extensions, it doesn't make sense to check updates for versions older than the installed version (if given), which would be sorted out anyway later in the extensions updater but not in the pre-update check.

Therefore I propose to extend the loadFromXml function of the updater library by an additional, optional parameter to specify the minimum extension version for which updates shall be searched.

The pre-update checker will pass the extension version to it and so limit the search for updates to versions >= installed.

This fixes my issue with the Patchtester compatible version for 3.10 and with the currently installed version not being shown when compatible mentioned in my comment here: https://github.com/joomla/joomla-cms/pull/35419#issuecomment-910115310

The reason why I think it has to be done like this is that only in the loadFromXml we check the compatibility and stability and so on and forget about that update as soon as we decide to check the next one in the list. So if we instead of that just decide later in the UI to show this or that version, we will not really know if the installed version was flagged as compatible or not.

And as I said, we cannot downgrade extensions, so I think it makes sense to just do it this way and using a minimum version to look for. This could be even used later at other places, too.

Please test my change and decide if you like to have that in your PR or if I shall make an own one as alternative (which contains your commits, too, so it would be co-work).

### Testing Instructions

Run the pre-update checker.

### Actual result in the 4.0-dev branch of the CMS repo **_without_** https://github.com/joomla/joomla-cms/pull/35419 and **_without_** this Pull Request

The weblinks component is shown in category "Update Required" because the current version 3.9.0-rc1 is not shown as Joomla 4 compatible version, see red mark in the below image.

For other extensions the currently installed version is shown as compatible because that is also the latest version of the particular extension, see the green marks in the below image.

![2021-09-05_j3-test-pr-35419_without-pr](https://user-images.githubusercontent.com/7413183/132122913-894807f5-8dc7-4af9-81a1-e77ea17e9eff.png)

### Actual result with https://github.com/joomla/joomla-cms/pull/35419 and **_without_** this Pull Request

The weblinks are shown in category "No Update Required".

The oldest compatible extension version is shown for the current and the target CMS versions.

This might be lower than the installed version of the particular extension, see red marks in the below image.

That might make people who have a quick look think that their currently installed version is not compatible if the version which is shown is older.

![2021-09-05_j3-test-pr-35419_with-pr](https://user-images.githubusercontent.com/7413183/132122457-bb31f127-5bef-4a96-8452-6e3489a00504.png)

### Expected result with https://github.com/joomla/joomla-cms/pull/35419 and **_with_** this Pull Request

If the currently installed version of an extension is compatible, it will be shown as such, see green marks in the below image.

Older versions than the installed one will not be shown as compatible versions.

![2021-09-05_j3-test-pr-35419_with-pr-plus-my-changes](https://user-images.githubusercontent.com/7413183/132122461-0f537178-d4c8-41d8-b8f6-99fc20ce7ebd.png)
