### PR TITLE
[CMS PR #35419] Show installed version of extension as compatible if so, and latest version if update required

### DIFF
--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -509,8 +509,8 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 
 		/** @var JoomlaupdateModelDefault $model */
 		$model = $this->getModel('default');
-		$upgradeCompatibilityStatus = $model->fetchCompatibility($extensionID, $joomlaTargetVersion);
-		$currentCompatibilityStatus = $model->fetchCompatibility($extensionID, $joomlaCurrentVersion);
+		$upgradeCompatibilityStatus = $model->fetchCompatibility($extensionID, $extensionVersion, $joomlaTargetVersion);
+		$currentCompatibilityStatus = $model->fetchCompatibility($extensionID, $extensionVersion, $joomlaCurrentVersion);
 
 		$upgradeWarning = 0;
 	

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1757,14 +1757,21 @@ ENDDATA;
 			return false;
 		}
 
-		$minVersion = $update->get('minCompatibleVersion')->_data;
-		$maxVersion = $update->get('version')->_data;
+		$maxVersion = $update->get('version');
+
+		if (empty($maxVersion))
+		{
+			return false;
+		}
+
+		$minVersion = $update->get('minCompatibleVersion');
 
 		// Return the latest available update version if the currently installed version is not known or not compatble
-		return empty($extensionVersion)
-			|| version_compare($maxVersion, $extensionVersion, '<')
-			|| version_compare($minVersion, $extensionVersion, '>')
-			? $maxVersion
+		return empty($minVersion)
+			|| empty($extensionVersion)
+			|| version_compare($maxVersion->_data, $extensionVersion, '<')
+			|| version_compare($minVersion->_data, $extensionVersion, '>')
+			? $maxVersion->_data
 			: $extensionVersion;
 	}
 

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1737,7 +1737,7 @@ ENDDATA;
 	 * @param   string  $extensionVersion     The items installed version
 	 * @param   string  $joomlaTargetVersion  The Joomla! version to test against
 	 *
-	 * @return  mixed  An array of data items or false.
+	 * @return  mixed  A string with the compatible version or false if no compatible version found.
 	 *
 	 * @since   3.10.0
 	 */
@@ -1760,6 +1760,7 @@ ENDDATA;
 		$minVersion = $update->get('minCompatibleVersion')->_data;
 		$maxVersion = $update->get('version')->_data;
 
+		// Return the latest available update version if the currently installed version is not compatble
 		return version_compare($maxVersion, $extensionVersion, '<') || version_compare($minVersion, $extensionVersion, '>')
 			? $maxVersion
 			: $extensionVersion;

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1760,8 +1760,10 @@ ENDDATA;
 		$minVersion = $update->get('minCompatibleVersion')->_data;
 		$maxVersion = $update->get('version')->_data;
 
-		// Return the latest available update version if the currently installed version is not compatble
-		return version_compare($maxVersion, $extensionVersion, '<') || version_compare($minVersion, $extensionVersion, '>')
+		// Return the latest available update version if the currently installed version is not known or not compatble
+		return empty($extensionVersion)
+			|| version_compare($maxVersion, $extensionVersion, '<')
+			|| version_compare($minVersion, $extensionVersion, '>')
 			? $maxVersion
 			: $extensionVersion;
 	}

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1571,13 +1571,14 @@ ENDDATA;
 	 * Called by controller's fetchExtensionCompatibility, which is called via AJAX.
 	 *
 	 * @param   string  $extensionID          The ID of the checked extension
+	 * @param   string  $extensionVersion     The installed version of the checked extension
 	 * @param   string  $joomlaTargetVersion  Target version of Joomla
 	 *
 	 * @return object
 	 *
 	 * @since 3.10.0
 	 */
-	public function fetchCompatibility($extensionID, $joomlaTargetVersion)
+	public function fetchCompatibility($extensionID, $extensionVersion, $joomlaTargetVersion)
 	{
 		$updateSites = $this->getUpdateSitesInfo($extensionID);
 
@@ -1594,7 +1595,7 @@ ENDDATA;
 
 				foreach ($updateFileUrls as $updateFileUrl)
 				{
-					$compatibleVersion = $this->checkCompatibility($updateFileUrl, $joomlaTargetVersion);
+					$compatibleVersion = $this->checkCompatibility($updateFileUrl, $extensionVersion, $joomlaTargetVersion);
 
 					if ($compatibleVersion)
 					{
@@ -1610,7 +1611,7 @@ ENDDATA;
 			}
 			else
 			{
-				$compatibleVersion = $this->checkCompatibility($updateSite['location'], $joomlaTargetVersion);
+				$compatibleVersion = $this->checkCompatibility($updateSite['location'], $extensionVersion, $joomlaTargetVersion);
 
 				if ($compatibleVersion)
 				{
@@ -1733,13 +1734,14 @@ ENDDATA;
 	 * Method to check non core extensions for compatibility.
 	 *
 	 * @param   string  $updateFileUrl        The items update XML url.
+	 * @param   string  $extensionVersion     The items installed version
 	 * @param   string  $joomlaTargetVersion  The Joomla! version to test against
 	 *
 	 * @return  mixed  An array of data items or false.
 	 *
 	 * @since   3.10.0
 	 */
-	private function checkCompatibility($updateFileUrl, $joomlaTargetVersion)
+	private function checkCompatibility($updateFileUrl, $extensionVersion, $joomlaTargetVersion)
 	{
 		// Get the minimum stability information from com_installer
 		$minimumStability = JComponentHelper::getParams('com_installer')->get('minimum_stability', JUpdater::STABILITY_STABLE);
@@ -1750,7 +1752,17 @@ ENDDATA;
 
 		$downloadUrl = $update->get('downloadurl');
 
-		return !empty($downloadUrl->_data) ? $update->get('minCompatibleVersion') : false;
+		if (empty($downloadUrl->_data))
+		{
+			return false;
+		}
+
+		$minVersion = $update->get('minCompatibleVersion');
+		$maxVersion = $update->get('version');
+
+		return version_compare($maxVersion, $extensionVersion, '<') || version_compare($minVersion, $extensionVersion, '>')
+			? $maxVersion
+			: $extensionVersion;
 	}
 
 	/**

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1600,7 +1600,7 @@ ENDDATA;
 					if ($compatibleVersion)
 					{
 						// Return the compatible version
-						return (object) array('state' => 1, 'compatibleVersion' => $compatibleVersion->_data);
+						return (object) array('state' => 1, 'compatibleVersion' => $compatibleVersion);
 					}
 					else
 					{
@@ -1616,7 +1616,7 @@ ENDDATA;
 				if ($compatibleVersion)
 				{
 					// Return the compatible version
-					return (object) array('state' => 1, 'compatibleVersion' => $compatibleVersion->_data);
+					return (object) array('state' => 1, 'compatibleVersion' => $compatibleVersion);
 				}
 				else
 				{
@@ -1757,8 +1757,8 @@ ENDDATA;
 			return false;
 		}
 
-		$minVersion = $update->get('minCompatibleVersion');
-		$maxVersion = $update->get('version');
+		$minVersion = $update->get('minCompatibleVersion')->_data;
+		$maxVersion = $update->get('version')->_data;
 
 		return version_compare($maxVersion, $extensionVersion, '<') || version_compare($minVersion, $extensionVersion, '>')
 			? $maxVersion


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/35419#issuecomment-910115310 .

Alternative to #3 .

### Summary of Changes

Show the currently installed version of an extension as compatible if that version is >= the oldest compatible version and <= the latest compatible version, otherwise if that is not the case always show the latest available compatible update.

In opposite to #3 , this PR here doesn't make any additional changes on the library (but more changes in the model), and in opposite to that PR and the CMS PR, this here still will show the latest available update version if an update is required, like it is now in the CMS in the 4.0-dev branch.

I think this is what a user will expect to see.

Also in opposite to #3 , this one here doesn't increase the possibility to get a "No Compatibility Information" because it doesn't limit the search for updates to versions newer than the installed one.

In addition, I added a check if the result of `$update->get('minCompatibleVersion')` is not empty so when a new version of the update component runs with the old updater library, like it would be after a separate update of the component for some other reason, there is no error because accessing an undefined property of a non object.

### Testing Instructions

On a 3.10.x, install some extensions, e.g. [patchtester 3.0.0](https://github.com/joomla-extensions/patchtester/releases/download/3.0.0/com_patchtester.zip) and [weblinks 3.9.10-rc1](https://github.com/joomla/joomla-cms/files/7074571/pkg-weblinks-3.9.0-rc1.zip).

Then set the update channel of the Joomla Update component to "Next" to get the pre-update checker for update to Joomla 4.x.

### Actual result in the 4.0-dev branch of the CMS repo **_without_** https://github.com/joomla/joomla-cms/pull/35419 and **_without_** this Pull Request

The weblinks component is shown in category "Update Required" because the current version 3.9.0-rc1 is not shown as Joomla 4 compatible version, see red mark in the below image.

For other extensions the currently installed version is shown as compatible because that is also the latest version of the particular extension, see the green marks in the below image.

![2021-09-05_j3-test-pr-35419_without-pr](https://user-images.githubusercontent.com/7413183/132122913-894807f5-8dc7-4af9-81a1-e77ea17e9eff.png)

### Actual result with https://github.com/joomla/joomla-cms/pull/35419 and **_without_** this Pull Request

The weblinks are shown in category "No Update Required".

The oldest compatible extension version is shown for the current and the target CMS versions.

This might be lower than the installed version of the particular extension, see red marks in the below image.

That might make people who have a quick look think that their currently installed version is not compatible if the version which is shown is older.

![2021-09-05_j3-test-pr-35419_with-pr](https://user-images.githubusercontent.com/7413183/132122457-bb31f127-5bef-4a96-8452-6e3489a00504.png)

### Expected result with https://github.com/joomla/joomla-cms/pull/35419 and **_with_** this Pull Request

If the currently installed version of an extension is compatible (or can be assumed to be compatible because between the oldest and newest compatible version), it will be shown as such, see green marks in the below image.

Otherwise the latest available update version will be shown, like it is when searching for updates in the installer.

![2021-09-05_j3-test-pr-35419_with-pr-plus-my-changes-new](https://user-images.githubusercontent.com/7413183/132127967-b76f61e2-f176-4635-be34-01a01978242f.png)

### Documentation Changes Required

None.