### PR TITLE
[CMS PR 39245] Fix transaction handling and data type error

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -465,7 +465,9 @@ class JoomlaInstallerScript
 
             try {
                 $db->transactionCommit();
-            } catch (\RuntimeException $e) {
+            }
+            catch (\PDOException $e)
+            {
                 // Ignore "no active transaction" exception
             }
         } catch (\Exception $e) {

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -444,7 +444,7 @@ class JoomlaInstallerScript
                         ->update($db->quoteName('#__fields_values'))
                         ->set($db->quoteName('value') . ' = ' . $db->quote(json_encode($newFieldValue)))
                         ->where($db->quoteName('field_id') . ' = ' . $rowFieldValue->field_id)
-                        ->where($db->quoteName('item_id') . ' =' . $rowFieldValue->item_id);
+                        ->where($db->quoteName('item_id') . ' =' . $db->quote($rowFieldValue->item_id));
                     $db->setQuery($query)
                         ->execute();
                 }

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -463,13 +463,7 @@ class JoomlaInstallerScript
             $installer->setDatabase($db);
             $installer->uninstall('plugin', $extensionId);
 
-            try {
-                $db->transactionCommit();
-            }
-            catch (\PDOException $e)
-            {
-                // Ignore "no active transaction" exception
-            }
+            $db->transactionCommit();
         } catch (\Exception $e) {
             $db->transactionRollback();
             throw $e;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -444,7 +444,7 @@ class JoomlaInstallerScript
                         ->update($db->quoteName('#__fields_values'))
                         ->set($db->quoteName('value') . ' = ' . $db->quote(json_encode($newFieldValue)))
                         ->where($db->quoteName('field_id') . ' = ' . $rowFieldValue->field_id)
-                        ->where($db->quoteName('item_id') . ' =' . $db->quote($rowFieldValue->item_id));
+                        ->where($db->quoteName('item_id') . ' = ' . $db->quote($rowFieldValue->item_id));
                     $db->setQuery($query)
                         ->execute();
                 }


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/39245 .

### Summary of Changes

- Use separate transactions for the migration of each single field and for the part with unprotecting and uninstalling the plugin to work around broken transaction handling caused by using `$fieldModel->save` but still leave consistent data after a failure.
- Quote string value for the `item_id` column when updating the `#__fields_values` table in order not to get an SQL data type error on PostgreSQL.

Feedback is welcome.

### Testing Instructions

Test https://github.com/joomla/joomla-cms/pull/39245 with diverse database types and drivers.

### Actual result BEFORE applying this Pull Request

Fails with MySQL (PDO) and PostgreSQL (PDO).

### Expected result AFTER applying this Pull Request

Works with MySQL and MariaDB, each with both the MySQLi and the MySQL (PDO) drivers, and with PostgreSQL (PDO).

### Documentation Changes Required

None.